### PR TITLE
Use reason_code instead of txn_type.

### DIFF
--- a/app/code/local/Aligent/Paypal/Model/Ipn.php
+++ b/app/code/local/Aligent/Paypal/Model/Ipn.php
@@ -25,7 +25,7 @@ class Aligent_Paypal_Model_Ipn extends Mage_Paypal_Model_Ipn
         $this->_debugData = array('ipn' => $request);
         ksort($this->_debugData['ipn']);
 
-        if (isset($this->_request['txn_type']) && 'mp_cancel' == $this->_request['txn_type']) {
+        if (isset($this->_request['reason_code']) && 'refund' == $this->_request['reason_code']) {
             $this->_registerMpCancel();
         } else {
             parent::processIpnRequest($request, $httpAdapter);


### PR DESCRIPTION
txn_type was not being returned when a refund was processed.  This caused the condition to fail and the credit memo to be created.  Using reason_code = 'refund' fixed the issue.