### PR TITLE
Set SSL version to TLS-1.2 for the IPN postback.

### DIFF
--- a/app/code/local/Aligent/Paypal/Model/Ipn.php
+++ b/app/code/local/Aligent/Paypal/Model/Ipn.php
@@ -107,7 +107,7 @@ class Aligent_Paypal_Model_Ipn extends Mage_Paypal_Model_Ipn
         $sReq = substr($sReq, 1);
         $this->_debugData['postback'] = $sReq;
         $this->_debugData['postback_to'] = $this->_config->getPaypalUrl();
-        $httpAdapter->addOption(CURLOPT_SSLVERSION,6);
+        $httpAdapter->addOption(CURLOPT_SSLVERSION,6); //6 == CURL_SSLVERSION_TLSv1_2
         $httpAdapter->write(Zend_Http_Client::POST, $this->_config->getPaypalUrl(), '1.1', array(), $sReq);
         try {
             $response = $httpAdapter->read();

--- a/app/code/local/Aligent/Paypal/Model/Ipn.php
+++ b/app/code/local/Aligent/Paypal/Model/Ipn.php
@@ -107,7 +107,7 @@ class Aligent_Paypal_Model_Ipn extends Mage_Paypal_Model_Ipn
         $sReq = substr($sReq, 1);
         $this->_debugData['postback'] = $sReq;
         $this->_debugData['postback_to'] = $this->_config->getPaypalUrl();
-
+        $httpAdapter->addOption(CURLOPT_SSLVERSION,6);
         $httpAdapter->write(Zend_Http_Client::POST, $this->_config->getPaypalUrl(), '1.1', array(), $sReq);
         try {
             $response = $httpAdapter->read();


### PR DESCRIPTION
@aligentjim Any concerns with this? As we discovered last week, the sandbox is rejecting non-TLS1.2 requests (production will begin doing so in June), which causes the IPN postback to throw a 500 error unless explicitly setting the SSL version.

For reference: https://devblog.paypal.com/upcoming-security-changes-notice/